### PR TITLE
#3 retry logic for error configuring network

### DIFF
--- a/DnsDirector.Service/DnsDirector.Service.log4net.xml
+++ b/DnsDirector.Service/DnsDirector.Service.log4net.xml
@@ -26,11 +26,12 @@
   <appender name="RollingFile" type="log4net.Appender.RollingFileAppender">
     <file value="DnsDirector.Service.log.txt" />
     <appendToFile value="true" />
-    <maximumFileSize value="100KB" />
-    <maxSizeRollBackups value="5" />
-
+    <rollingStyle value="Size" />
+    <maxSizeRollBackups value="10" />
+    <maximumFileSize value="512KB" />
+    <staticLogFileName value="true" />
     <layout type="log4net.Layout.PatternLayout">
-      <conversionPattern value="%date [%thread] %-5level %logger [%ndc] - %message%newline" />
+      <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
     </layout>
   </appender>
 

--- a/DnsDirector.Service/Program.cs
+++ b/DnsDirector.Service/Program.cs
@@ -24,7 +24,7 @@ namespace DnsDirector.Service
 
             ConfigureLog();
 
-            log.Debug($"Main({string.Join(", ", args.Select(arg => $"\"{arg}\""))})");
+            log.Info($"Main({string.Join(", ", args.Select(arg => $"\"{arg}\""))})");
 
             try
             {
@@ -35,12 +35,12 @@ namespace DnsDirector.Service
                 log.Fatal("Uncaught top level exception.", ex);
                 Environment.Exit(-1);
             }
-
-            log.Debug("Main: void");
+            log.Info("Main: void");
         }
 
         private static void Run(string[] args)
         {
+            log.Debug($"Run({string.Join(", ", args.Select(arg => $"\"{arg}\""))})");
             IsService = false;
             var svc = new Service();
             if (args.Any())
@@ -52,6 +52,7 @@ namespace DnsDirector.Service
                 IsService = true;
                 ServiceBase.Run(svc);
             }
+            log.Debug("Run: void");
         }
 
         private static void HandleArgs(string[] args, Service svc)
@@ -91,6 +92,7 @@ namespace DnsDirector.Service
             try
             {
                 XmlConfigurator.ConfigureAndWatch(new FileInfo(log4netConfigFile));
+                log.Info($"Configured log4net with file: {log4netConfigFile}");
             }
             catch (Exception ex)
             {
@@ -109,7 +111,7 @@ namespace DnsDirector.Service
             Console.WriteLine("\tDnsDirector.Service.exe --console");
             Console.WriteLine("\t\tRun in the foreground with a console.");
             Console.WriteLine("\tDnsDirector.Service.exe --reset");
-            Console.WriteLine("\t\tReset any DnsDirector specific network settings.");
+            Console.WriteLine("\t\tReset any DnsDirector specific network settings and exit.");
             Console.WriteLine("\tDnsDirector.Service.exe");
             Console.WriteLine("\t\tRun as a Windows service. (Not from command prompt.)");
         }

--- a/DnsDirector.Service/Service.cs
+++ b/DnsDirector.Service/Service.cs
@@ -72,6 +72,7 @@ namespace DnsDirector.Service
                 log.Fatal($"Error starting service", ex);
                 StopService();
             }
+            log.Info("OnStart: void");
         }
 
         private async Task Startup(Action<Exception> fatalError)
@@ -99,6 +100,7 @@ namespace DnsDirector.Service
                 log.Fatal("Exception in service stop, terminating!", ex);
                 Environment.Exit(-1);
             }
+            log.Info("OnStop: void");
         }
 
         private void Shutdown()
@@ -106,24 +108,23 @@ namespace DnsDirector.Service
             log.Debug("Shutdown()");
             network.Stop();
             server.Stop();
+            log.Debug("Shutdown: void");
         }
 
-        private Task StopService()
+        private void StopService()
         {
             log.Debug("StopService()");
-            return Task.Run(() =>
+            if (!Program.IsService) return;
+            try
             {
-                if (!Program.IsService) return;
-                try
-                {
-                    Stop();
-                }
-                catch(Exception ex)
-                {
-                    log.Fatal("Exception stopping service, terminating!", ex);
-                    Environment.Exit(-1);
-                }
-            });
+                Stop();
+            }
+            catch(Exception ex)
+            {
+                log.Fatal("Exception stopping service, terminating!", ex);
+                Environment.Exit(-1);
+            }
+            log.Debug("StopService: void");
         }
     }
 }


### PR DESCRIPTION
#3 A fix for the symptom that was causing the unhandled exception. (Now will retry network operations a few times to make sure sleep/hibernate related exceptions don't cause a fatal exception.) But the underlying issue of not stopping cleanly on a fatal exception is still outstanding.
